### PR TITLE
タイポ修正

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -10,7 +10,7 @@ abstract class Application
     protected $router;
     protected $login_action = array();
 
-    public function __construct()
+    public function __construct($debug = false)
     {
         $this->setDebugMode($debug);
         $this->initialize();
@@ -147,7 +147,7 @@ EOF
 
     protected function findController($controller_class)
     {
-        if(!class_exist($controller_class)){
+        if(!class_exists($controller_class)){
             $controller_class = $this->getControllerDir() . '/' . $controller_class . 'php';
             if(!is_readable($controller_file)){
                 return false;

--- a/core/ClassLoader.php
+++ b/core/ClassLoader.php
@@ -11,7 +11,7 @@ class ClassLoader
 
     public function registerDir($dir)
     {
-        $this->dirs[] = $dirs;
+        $this->dirs[] = $dir;
     }
 
     public function loadClass($class)


### PR DESCRIPTION
・Applicationクラスのclass_exist=>class_exists
・Applicationクラスのコンストラクタの引数漏れ(デバッグ用)
・ClassLoaderの引数と変数のタイポ